### PR TITLE
Messenger Overhaul

### DIFF
--- a/game/route_setup.rpy
+++ b/game/route_setup.rpy
@@ -302,7 +302,8 @@ init -6 python:
             if notify_player:
                 # Let the player know a new chatroom is open
                 the_msg = "[[new chatroom] " + current_chatroom.title
-                renpy.music.play('audio/sfx/Ringtones etc/text_basic_1.wav', 'sound')
+                renpy.music.play('audio/sfx/Ringtones etc/text_basic_1.wav', 
+                                    'sound')
                 renpy.show_screen('confirm', 
                         message=the_msg, yes_action=Hide('confirm'))
             # We also deliver any incoming calls in the event 

--- a/game/text_message_definitions.rpy
+++ b/game/text_message_definitions.rpy
@@ -336,6 +336,9 @@ label compose_text_end(text_label=False):
 label text_end():
     if text_person is not None and text_person.real_time_text:
         answer "" (pauseVal=1.0)
+    if (len(text_person.text_msg.msg_log) > 0
+            and text_person.text_msg.msg_log[-1].who.file_id == 'delete'):
+        $ text_person.txt_msg.msg_log.pop()  
     $ text_msg_reply = False
     #if text_person is not None and text_person.real_time_text:
     $ text_person.finished_text()
@@ -347,7 +350,7 @@ label text_end():
     hide screen text_answer
     hide screen inactive_text_answer
     hide screen text_play_button
-    hide screen text_pause_button    
+    hide screen text_pause_button  
     call screen text_message_screen(who)         
     # else:
     #     $ renpy.retain_after_load()


### PR DESCRIPTION
This branch cleans up a lot of code oddities across the board. Most notable are the changes to the messenger and text message systems, which are more consistent with each other and have also had greatly reduced code. The file structure has also been altered for ease of use, and many screens have been updated with easier-to-understand styles. There is also a messenger replay system which requires no input from the user. Both regular and real-time text messages can be switched between on a per-conversation basis rather than as a global toggle. Many bugs have been fixed, such as a bug that would not return you to the correct chat hub screen after loading.